### PR TITLE
Ratio plot fixes

### DIFF
--- a/FileParser.cxx
+++ b/FileParser.cxx
@@ -73,6 +73,13 @@ void FileParser::OpenFile(TString fname, TString cyclename)
     fname.Prepend(Prefix);
   }  
 
+  // check if input filename has .root extension
+  // necessary for extracting process name and creating ratio plots
+  if (!fname.EndsWith(".root")){
+    cerr << "fInputFiles entry must end with .root, instead got " << fname << endl;;
+    exit(EXIT_FAILURE);
+  }
+
   // check if name consists of a wildcard, if so use hadd to combine histograms
   if (fname.Contains("*")){
     TString target(fname);
@@ -154,6 +161,12 @@ void FileParser::OpenThetaFile(TString cyclename)
 
   // fname = target;
 
+  // check if input filename has .root extension
+  // necessary for extracting process name and creating ratio plots
+  if (!fname.EndsWith(".root")){
+    cerr << "fCycleName must end with .root, instead got " << fname << endl;;
+    exit(EXIT_FAILURE);
+  }
 
   if (debug) cout << "Opening file with name " << fname << "..." << endl;
   m_file = new TFile(fname, "READ");

--- a/SPlotter.cxx
+++ b/SPlotter.cxx
@@ -1034,7 +1034,7 @@ vector<SHist*> SPlotter::CalcRatios(vector<SHist*> hists)
     Double_t rel_err = err / val;
     rdhist->SetBinError(ibin, rel_err * rdhist->GetBinContent(ibin) );
   }
-  rdhist->GetYaxis()->SetTitle(rd->GetProcessName() + " / BG");
+  rdhist->GetYaxis()->SetTitle(rd->GetLegName() + " / BG");
   if (bSingleEPS){
     SingleEPSRatioCosmetics(rdhist);
   } else {


### PR DESCRIPTION
- Use the legend name for the ratio plot instead of process name for consistency

- Since `FileParser::StoreProcessName` depends on there being a `.root` in the filename, now explicitly checks that the user has one, both for "normal" input, and theta input. Although the code works without one, it would fail to draw a ratio plot (because of lack of process name, which is used e.g. to figure out which hist is data).